### PR TITLE
Set up theme toggle functionality

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,7 +14,9 @@
         "node-sass": "^7.0.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-responsive": "^10.0.0",
         "react-scripts": "5.0.1",
+        "react-toggle": "^4.1.3",
         "web-vitals": "^2.1.4"
       }
     },
@@ -6312,6 +6314,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
       "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q=="
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
     "node_modules/clean-css": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -6696,6 +6703,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q=="
     },
     "node_modules/css-minimizer-webpack-plugin": {
       "version": "3.4.1",
@@ -10008,6 +10020,11 @@
         "ms": "^2.0.0"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.5.tgz",
+      "integrity": "sha512-fedL7PRwmeVkgyhu9hLeTBaI6wcGk7JGJswdaRsa5aUbkXI1kr1xZwTPBtaYPpwf56878iDek6VbVnuWMebJmw=="
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -13194,6 +13211,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/matchmediaquery": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.4.2.tgz",
+      "integrity": "sha512-wrZpoT50ehYOudhDjt/YvUJc6eUzcdFPdmbizfgvswCKNHD1/OBOHYJpHie+HXpu6bSkEGieFMYk6VuutaiRfA==",
+      "dependencies": {
+        "css-mediaquery": "^0.1.2"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -16278,6 +16303,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-responsive": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-10.0.0.tgz",
+      "integrity": "sha512-N6/UiRLGQyGUqrarhBZmrSmHi2FXSD++N5VbSKsBBvWfG0ZV7asvUBluSv5lSzdMyEVjzZ6Y8DL4OHABiztDOg==",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.0",
+        "matchmediaquery": "^0.4.2",
+        "prop-types": "^15.6.1",
+        "shallow-equal": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -16348,6 +16390,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-toggle": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/react-toggle/-/react-toggle-4.1.3.tgz",
+      "integrity": "sha512-WoPrvbwfQSvoagbrDnXPrlsxwzuhQIrs+V0I162j/s+4XPgY/YDAUmHSeWiroznfI73wj+MBydvW95zX8ABbSg==",
+      "dependencies": {
+        "classnames": "^2.2.5"
+      },
+      "peerDependencies": {
+        "prop-types": ">= 15.3.0 < 19",
+        "react": ">= 15.3.0 < 19",
+        "react-dom": ">= 15.3.0 < 19"
       }
     },
     "node_modules/read-cache": {
@@ -17325,6 +17380,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/shallow-equal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
+      "integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,9 @@
     "node-sass": "^7.0.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-responsive": "^10.0.0",
     "react-scripts": "5.0.1",
+    "react-toggle": "^4.1.3",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,6 +1,9 @@
+import ThemeToggle from "./components/ThemeToggle";
+
 function App() {
   return (
     <div className="App">
+      <ThemeToggle />
     </div>
   );
 }

--- a/client/src/components/ThemeToggle.jsx
+++ b/client/src/components/ThemeToggle.jsx
@@ -1,0 +1,34 @@
+import React, { useState, useEffect } from "react";
+import "react-toggle/style.css";
+import Toggle from "react-toggle";
+import {useMediaQuery} from "react-responsive";
+
+function ThemeToggle() {
+    const systemPrefersDark = useMediaQuery({query: "(prefers-color-scheme: dark)"});
+    const [isDark, setIsDark] = useState(systemPrefersDark);
+
+    useEffect(() => {
+        setIsDark(systemPrefersDark);
+        console.log("System prefers dark mode:", systemPrefersDark);
+    }, [systemPrefersDark]);
+
+    const handleToggleChange = ({target}) => {
+        console.log("Toggle checked:", target.checked);
+        setIsDark(target.checked)
+    }
+
+    useEffect(() => {
+        document.documentElement.className = isDark ? "dark-mode" : "light-mode";
+    }, [isDark])
+
+    return (
+        <Toggle
+            checked={isDark}
+            onChange={handleToggleChange}
+            icons={{ checked: "🌙", unchecked: "☀️" }}
+            aria-label="Light Dark mode toggle"
+    />
+    );
+}
+
+export default ThemeToggle;

--- a/client/src/css/main.css
+++ b/client/src/css/main.css
@@ -2,4 +2,19 @@
   margin: 0;
   padding: 0;
   box-sizing: border-box;
+}
+
+html {
+  background-color: #fafafa;
+  color: #1f2023;
+}
+
+html.dark-mode {
+  background-color: #1f2023;
+  color: #efefef;
+}
+
+html.light-mode {
+  background-color: #fafafa;
+  color: #1f2023;
 }/*# sourceMappingURL=main.css.map */

--- a/client/src/css/main.css.map
+++ b/client/src/css/main.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sourceRoot":"","sources":["../scss/_general-styling.scss"],"names":[],"mappings":"AAAA;EACI;EACA;EACA","file":"main.css"}
+{"version":3,"sourceRoot":"","sources":["../scss/_general-styling.scss","../scss/_custome-variables.scss"],"names":[],"mappings":"AAAA;EACI;EACA;EACA;;;AAGJ;EACI,kBCPmB;EDQnB,OCPuB;;;ADW3B;EACI,kBCVkB;EDWlB,OCVsB;;;ADatB;EACI,kBClBe;EDmBf,OClBmB","file":"main.css"}

--- a/client/src/scss/_custome-variables.scss
+++ b/client/src/scss/_custome-variables.scss
@@ -1,0 +1,5 @@
+$lightBackgroundColor: #fafafa;
+$lightBackgroundTextColor: #1f2023;
+
+$darkBackgroundColor: #1f2023;
+$darkBackgroundTextColor: #efefef;

--- a/client/src/scss/_general-styling.scss
+++ b/client/src/scss/_general-styling.scss
@@ -3,3 +3,19 @@
     padding: 0;
     box-sizing: border-box;
 }
+
+html {
+    background-color: $lightBackgroundColor;
+    color: $lightBackgroundTextColor;
+}
+
+
+html.dark-mode {
+    background-color: $darkBackgroundColor;
+    color: $darkBackgroundTextColor;
+}
+
+    html.light-mode {
+        background-color: $lightBackgroundColor;
+        color: $lightBackgroundTextColor;
+    }

--- a/client/src/scss/main.scss
+++ b/client/src/scss/main.scss
@@ -1,2 +1,2 @@
-@import "./general-styling";
 @import "./custome-variables";
+@import "./general-styling";


### PR DESCRIPTION
In this commit, I:

## General Explanation
1. Created the `ThemeToggle` component where the theme toggling logic was implemented.
2. Used the `prefers-color-scheme` CSS media feature to display a light or dark color scheme based on the user's operating system setting preference.
3. Created custom variables for my color scheme in the `_custom-variables.scss` file.
4. Added the npm dependency [react-toggle](https://www.npmjs.com/package/react-toggle) to generate a sliding toggle rather than a button.
5. Added the npm dependency [react-responsive](https://www.npmjs.com/package/react-responsive) to utilize the `useMediaQuery` hook, prioritizing the user's operating system settings instead of manually assigning the theme setting as dark.

## Specific Explanation
1. Created the `systemPrefersDark` variable to store the boolean return value of the `useMediaQuery` hook. If true, this value indicates that the user's operating system prefers dark mode; otherwise, it returns false.
2. Placed the `systemPrefersDark` value inside the React `useState` hook as the default state.
3. The first `useEffect` hook dynamically updates the `isDark` state if the user changes their operating system preferences.
4. Created the `handleToggleChange` function to be used in the `onChange` attribute of the `<Toggle />` element. This function changes the theme when the user interacts with the toggle. When `target.checked` is true, it sets the value for `isDark` to true.
5. The final `useEffect` hook uses the boolean value of `isDark` to add the class "dark-mode" or "light-mode" to the `<html>` element. Depending on the value, the content is displayed with the correct theme.
